### PR TITLE
Fix macOS deprecation warning

### DIFF
--- a/Casks/rig.rb
+++ b/Casks/rig.rb
@@ -13,8 +13,6 @@ cask "rig" do
   desc "The R Installation Manager"
   homepage "https://github.com/r-lib/rig"
 
-  depends_on macos: ">= :el_capitan"
-
   if Hardware::CPU.intel?
     pkg "rig-#{version}-macOS-x86_64.pkg"
   else

--- a/Casks/rim.rb
+++ b/Casks/rim.rb
@@ -13,8 +13,6 @@ cask "rim" do
   desc "The R Installation Manager"
   homepage "https://github.com/gaborcsardi/rim"
 
-  depends_on macos: ">= :el_capitan"
-
   if Hardware::CPU.intel?
     pkg "rim-#{version}-macOS-x86_64.pkg"
   else


### PR DESCRIPTION
Fixes #1: macOS deprecation warning for `depends_on macos: :el_capitan`.

Removed dependency check as it is no longer needed for Homebrew.