### PR TITLE
Remove deprecated macOS dependency

### DIFF
--- a/Casks/rig.rb
+++ b/Casks/rig.rb
@@ -13,8 +13,6 @@ cask "rig" do
   desc "The R Installation Manager"
   homepage "https://github.com/r-lib/rig"
 
-  depends_on macos: ">= :el_capitan"
-
   if Hardware::CPU.intel?
     pkg "rig-#{version}-macOS-x86_64.pkg"
   else


### PR DESCRIPTION
## Overview

Removes the deprecated `depends_on macos: ">= :el_capitan"` directive from `Casks/rig.rb`.

## Problem

Currently, running `brew outdated` produces the following warning:

```
Warning: Calling `depends_on macos: :el_capitan` is deprecated! There is no replacement.
Please report this issue to the r-lib/homebrew-rig tap (not Homebrew/* repositories):
  /opt/homebrew/Library/Taps/r-lib/homebrew-rig/Casks/rig.rb:16
```
## Solution

- Removed line 16: `depends_on macos: ">= :el_capitan"`
- Current Homebrew already requires newer macOS versions
- This dependency specification can be safely removed

## Testing Environment

- macOS: 15.7.1 (Sequoia, ARM64)
- Homebrew: 5.0.8
- Verified Ruby syntax is valid after the change